### PR TITLE
Move from downloading the archived artifact to the pure executable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 kubectl_version: "1.16.3"
 # SHA512 checksum of the archive (see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md
 # for the checksums)
-kubectl_checksum: "sha512:904604839bbf46c11c7934f6f906adbc968234044b9f3268b71c175241626f8d4076812aca789dc5aa2f85fd25a384ad779638231d4d94f3f3c6d043b5d9f062"
+kubectl_checksum: "sha512:67a75b26d692b88a04215e78903e7e3d5f177ff6abfa77037e09cfa256f9d37068c7c5d39040b43604cfda9ed1f69166835cda76009a1c43b1f428e69f5243cc"
 # Where to install "kubectl" binary
 kubectl_bin_directory: "/usr/local/bin"
 # Directory to store the kubeclient archive

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,23 +1,15 @@
 ---
 - name: Download kubernetes-client archive
   get_url:
-    url: "https://dl.k8s.io/v{{ kubectl_version }}/kubernetes-client-{{ kubectl_os }}-{{ kubectl_arch }}.tar.gz"
+    url: "https://storage.googleapis.com/kubernetes-release/release/v{{ kubectl_version }}/bin/{{ kubectl_os }}/{{ kubectl_arch }}/kubectl"
     checksum: "{{ kubectl_checksum }}"
     dest: "{{ kubectl_tmp_directory }}"
   tags:
     - kubectl
 
-- name: Unarchive kubernetes-client
-  unarchive:
-    src: "{{ kubectl_tmp_directory }}/kubernetes-client-{{ kubectl_os }}-{{ kubectl_arch }}.tar.gz"
-    dest: "{{ kubectl_tmp_directory }}"
-    remote_src: yes
-  tags:
-    - kubectl
-
 - name: Copy kubectl binary to destination directory
   copy:
-    src: "{{ kubectl_tmp_directory }}/kubernetes/client/bin/{{ item }}"
+    src: "{{ kubectl_tmp_directory }}/{{ item }}"
     dest: "{{ kubectl_bin_directory }}/{{ item }}"
     mode: 0755
     owner: "{{ kubectl_owner }}"


### PR DESCRIPTION
* this solves https://github.com/viasite-ansible/ansible-role-zsh/issues/18
* all though, `unarchive` should not be used for uncompressing, in the first place (see *Synopsis* on https://docs.ansible.com/ansible/latest/modules/unarchive_module.html)
* an alternative approach to solve this issue would be to introduce https://github.com/andrewrothstein/ansible-unarchive-deps as a dependency to this role (like https://github.com/andrewrothstein/ansible-kubernetes-helm does it). But I would strongly advise against this, since it (a) is an additional dep and (b) it installs even more executables
* checksums can be obtained via https://storage.googleapis.com/kubernetes-release/release/v1.16.3/bin/linux/amd64/kubectl.[md5,sha1,sha256,sha516]
* `dl.k8s.io` ultimately 301es to GCP bucket
