### PR TITLE
Update to kubectl v1.22.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+**17.0.0+1.22.4**
+
+- update default kubectl to v1.22.4
+- add Molecule tests for Debian 10 + 11
+- remove Ubuntu 16.04 (Xenial) support
+- separate vars for Ubuntu 10+11 in Molecule test to test kubectl_download_filetype option
+- update min. Ansible version to 2.9
+
 **16.0.0+1.22.1**
 
 - update default kubectl to v1.22.1

--- a/README.md
+++ b/README.md
@@ -75,13 +75,19 @@ Afterwards molecule can be executed:
 molecule converge
 ```
 
-This will setup two Docker container with Ubuntu 20.04 and 18.04 with `kubectl` installed. So you should be able to execute the following commands if everything worked well:
+This will setup a few Docker container with Ubuntu 18.04 + 20.04 and Debian 10 + 11 with `kubectl` installed. So you should be able to execute the following commands if everything worked well (depending on the `kubectl` version the output will vary of course):
 
 ```bash
+docker exec -it test-ubuntu-1804 kubectl version --client=true
+Client Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.2", GitCommit:"faecb196815e248d3ecfb03c680a4507229c2a56", GitTreeState:"clean", BuildDate:"2021-01-13T13:28:09Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}
+
 docker exec -it test-ubuntu-2004 kubectl version --client=true
 Client Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.2", GitCommit:"faecb196815e248d3ecfb03c680a4507229c2a56", GitTreeState:"clean", BuildDate:"2021-01-13T13:28:09Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}
 
-docker exec -it test-ubuntu-1804 kubectl version --client=true
+docker exec -it test-kubectl-debian10 kubectl version --client=true
+Client Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.2", GitCommit:"faecb196815e248d3ecfb03c680a4507229c2a56", GitTreeState:"clean", BuildDate:"2021-01-13T13:28:09Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}
+
+docker exec -it test-kubectl-debian11 kubectl version --client=true
 Client Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.2", GitCommit:"faecb196815e248d3ecfb03c680a4507229c2a56", GitTreeState:"clean", BuildDate:"2021-01-13T13:28:09Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Role Variables
 ```yaml
 ---
 # "kubectl" version to install
-kubectl_version: "1.22.1"
+kubectl_version: "1.22.4"
 
 # The default "archive" will download "kubectl" as a ".tar.gz" file. This is
 # about 2.5x smaller then "binary" but the tarball needs to be unarchived
@@ -31,9 +31,9 @@ kubectl_version: "1.22.1"
 # over mobile link) stay with "archive". Otherwise "binary" might be an option.
 kubectl_download_filetype: "binary"
 # SHA512 checksum of the .tar.gz file (see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md#client-binaries)
-kubectl_checksum_archive: "sha512:064bd1eaf468c9b4a00e31bec3f9c80850c52cd1e06edfd86f307236acbdba7c89dbe663cbfefdc5ead72f1cb93ba9d21d828558508f0b29f8c814d9085846ca"
-# SHA512 checksum of the binary (see https://storage.googleapis.com/kubernetes-release/release/v1.22.1/bin/linux/amd64/kubectl.sha512)
-kubectl_checksum_binary: "sha512:84f16e9d9659407d8a88b3482f42631944744edc9d16ed11af3ea11ae61a99047b31a068d5618e1b03eb87219a1b979138ccba1f783d0fd7fc7f4b23e39c2844"
+kubectl_checksum_archive: "sha512:a3da93d56c64a80adc5b58044ecb52204507c733350972e7448e759c040fe3f72584f20d88a46b23bed9f021fc745cdb0530619416006170392d4fb7f69b28f5"
+# SHA512 checksum of the binary (see https://storage.googleapis.com/kubernetes-release/release/v1.22.4/bin/linux/amd64/kubectl.sha512)
+kubectl_checksum_binary: "sha512:38ef6189d570c952cd7524224fd99a41764adb6688eb93686e3f9759423d707ef9d39edf69ea1fc6f3247e451c59894b85fc62195d8de8c691618d11a960a741"
 
 # Where to install "kubectl" binary
 kubectl_bin_directory: "/usr/local/bin"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # "kubectl" version to install
-kubectl_version: "1.22.1"
+kubectl_version: "1.22.4"
 
 # The default "archive" will download "kubectl" as a ".tar.gz" file. This is
 # about 2.5x smaller then "binary" but the tarball needs to be unarchived
@@ -12,9 +12,9 @@ kubectl_version: "1.22.1"
 # over mobile link) stay with "archive". Otherwise "binary" might be an option.
 kubectl_download_filetype: "binary"
 # SHA512 checksum of the .tar.gz file (see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md#client-binaries)
-kubectl_checksum_archive: "sha512:064bd1eaf468c9b4a00e31bec3f9c80850c52cd1e06edfd86f307236acbdba7c89dbe663cbfefdc5ead72f1cb93ba9d21d828558508f0b29f8c814d9085846ca"
-# SHA512 checksum of the binary (see https://storage.googleapis.com/kubernetes-release/release/v1.22.1/bin/linux/amd64/kubectl.sha512)
-kubectl_checksum_binary: "sha512:84f16e9d9659407d8a88b3482f42631944744edc9d16ed11af3ea11ae61a99047b31a068d5618e1b03eb87219a1b979138ccba1f783d0fd7fc7f4b23e39c2844"
+kubectl_checksum_archive: "sha512:a3da93d56c64a80adc5b58044ecb52204507c733350972e7448e759c040fe3f72584f20d88a46b23bed9f021fc745cdb0530619416006170392d4fb7f69b28f5"
+# SHA512 checksum of the binary (see https://storage.googleapis.com/kubernetes-release/release/v1.22.4/bin/linux/amd64/kubectl.sha512)
+kubectl_checksum_binary: "sha512:38ef6189d570c952cd7524224fd99a41764adb6688eb93686e3f9759423d707ef9d39edf69ea1fc6f3247e451c59894b85fc62195d8de8c691618d11a960a741"
 
 # Where to install "kubectl" binary
 kubectl_bin_directory: "/usr/local/bin"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,6 @@ galaxy_info:
   platforms:
   - name: Ubuntu
     versions:
-    - xenial
     - bionic
     - focal
   galaxy_tags:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Robert Wimmer
   description: Installs kubectl command line utility used to interact with the Kubernetes API Server.
   license: GPLv3
-  min_ansible_version: 2.2
+  min_ansible_version: 2.9
   platforms:
   - name: Ubuntu
     versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,6 +9,10 @@ galaxy_info:
       versions:
         - bionic
         - focal
+    - name: Debian
+      versions:
+        - buster
+        - bullseye
   galaxy_tags:
     - kubernetes
     - kubectl

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,10 +5,10 @@ galaxy_info:
   license: GPLv3
   min_ansible_version: 2.9
   platforms:
-  - name: Ubuntu
-    versions:
-    - bionic
-    - focal
+    - name: Ubuntu
+      versions:
+        - bionic
+        - focal
   galaxy_tags:
     - kubernetes
     - kubectl

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,3 +1,4 @@
+---
 galaxy_info:
   author: Robert Wimmer
   description: Installs kubectl command line utility used to interact with the Kubernetes API Server.

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -12,6 +12,16 @@
     - name: Call setup
       setup:
 
+- hosts: test-kubectl-1804,test-kubectl-2004
+  vars_files:
+    - vars/ubuntu.yml
+  tasks:
+    - name: Include kubectl role
+      include_role:
+        name: githubixx.kubectl
+
+- hosts: test-kubectl-debian10,test-kubectl-debian11
+  tasks:
     - name: Include kubectl role
       include_role:
         name: githubixx.kubectl

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -11,11 +11,17 @@ lint: |
   ansible-lint .
 
 platforms:
-  - name: test-ubuntu-2004
+  - name: test-kubectl-2004
     image: ubuntu:20.04
     pre_build_image: true
-  - name: test-ubuntu-1804
+  - name: test-kubectl-1804
     image: ubuntu:18.04
+    pre_build_image: true
+  - name: test-kubectl-debian10
+    image: debian:10
+    pre_build_image: true
+  - name: test-kubectl-debian11
+    image: debian:11
     pre_build_image: true
 
 provisioner:

--- a/molecule/default/vars/ubuntu.yml
+++ b/molecule/default/vars/ubuntu.yml
@@ -1,0 +1,2 @@
+---
+kubectl_download_filetype: "archive"

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,2 +1,0 @@
-localhost
-

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,0 @@
----
-- hosts: localhost
-  remote_user: root
-  roles:
-    - .


### PR DESCRIPTION
- update default kubectl to v1.22.4
- add Molecule tests for Debian 10 + 11
- remove Ubuntu 16.04 (Xenial) support
- separate vars for Ubuntu 10+11 in Molecule test to test kubectl_download_filetype option
- update min. Ansible version to 2.9