### PR TITLE
22.0.1+1.27.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - update kubectl to `v1.27.4`
 - remove Ubuntu `18.04` support (reached EOL)
+- remove Debian `10` (Buster) support (reached EOL)
 
 ## 22.0.0+1.27.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 22.0.1+1.27.4
+
+- update kubectl to `v1.27.4`
+
 ## 22.0.0+1.27.1
 
 - update kubectl to `v1.27.1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - update kubectl to `v1.27.4`
 - remove Ubuntu `18.04` support (reached EOL)
 - remove Debian `10` (Buster) support (reached EOL)
+- add Debian `12` (Bookworm) support
 
 ## 22.0.0+1.27.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - remove Ubuntu `18.04` support (reached EOL)
 - remove Debian `10` (Buster) support (reached EOL)
 - add Debian `12` (Bookworm) support
+- refactor Molecule test
 
 ## 22.0.0+1.27.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 22.0.1+1.27.4
 
 - update kubectl to `v1.27.4`
+- remove Ubuntu `18.04` support (reached EOL)
 
 ## 22.0.0+1.27.1
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Afterwards molecule can be executed:
 molecule converge
 ```
 
-This will setup a few Docker container with Ubuntu 18.04 + 20.04 and Debian 10 + 11 with `kubectl` installed. To verify if everything worked:
+This will setup a few Docker container with Ubuntu 20.04/22.04 and Debian 10 + 11 with `kubectl` installed. To verify if everything worked:
 
 ```bash
 molecule verify

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Afterwards molecule can be executed:
 molecule converge
 ```
 
-This will setup a few Docker container with Ubuntu 20.04/22.04 and Debian 10 + 11 with `kubectl` installed. To verify if everything worked:
+This will setup a few Docker container with Ubuntu 20.04/22.04 and Debian 11/12 with `kubectl` installed. To verify if everything worked:
 
 ```bash
 molecule verify

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Role Variables
 ```yaml
 ---
 # "kubectl" version to install
-kubectl_version: "1.27.1"
+kubectl_version: "1.27.4"
 
 # The default "archive" will download "kubectl" as a ".tar.gz" file. This is
 # about 2.5x smaller then "binary" but the tarball needs to be unarchived
@@ -31,9 +31,9 @@ kubectl_version: "1.27.1"
 # over mobile link) stay with "archive". Otherwise "binary" might be an option.
 kubectl_download_filetype: "binary"
 # SHA512 checksum of the .tar.gz file (see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#client-binaries)
-kubectl_checksum_archive: "sha512:98caa662a63d7f9ba36761caaf997be4d214ea2b921a4387965a67d168b52ea29ae9185de20192f7b4b9169a887beb19d22e5776ff0bb0b68907e177b11a8043"
-# SHA512 checksum of the binary (see https://storage.googleapis.com/kubernetes-release/release/v1.27.1/bin/linux/amd64/kubectl.sha512)
-kubectl_checksum_binary: "sha512:45c837500fd821553a76dfec626cbbe44ac9c5c2c82984e8cd1073615ed4707e69b0f6bd7adf001e0ddbcc89ccc7bca38162e7ee778473d59a09c91f3d99f7c2"
+kubectl_checksum_archive: "sha512:42ac0cdfb1d961cb14fbdf09370b0798a1cd687d576ded4c85a2574a2adc48e514c7df9c905f1e851fab2f69246efee73971fd39838351d3b194881cfa3b5409"
+# SHA512 checksum of the binary (see https://storage.googleapis.com/kubernetes-release/release/v1.27.4/bin/linux/amd64/kubectl.sha512)
+kubectl_checksum_binary: "sha512:73f3c5f343d52f5d87563666ed7ee0ccca84a1bc6dfb34d10baf9e3af1adf2358d4218a3ac4f8e8329a12c01dbf6dbbd8e77ff410041bfed93d979580d9bc749"
 
 # Where to install "kubectl" binary
 kubectl_bin_directory: "/usr/local/bin"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # "kubectl" version to install
-kubectl_version: "1.27.1"
+kubectl_version: "1.27.4"
 
 # The default "archive" will download "kubectl" as a ".tar.gz" file. This is
 # about 2.5x smaller then "binary" but the tarball needs to be unarchived
@@ -12,9 +12,9 @@ kubectl_version: "1.27.1"
 # over mobile link) stay with "archive". Otherwise "binary" might be an option.
 kubectl_download_filetype: "binary"
 # SHA512 checksum of the .tar.gz file (see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#client-binaries)
-kubectl_checksum_archive: "sha512:98caa662a63d7f9ba36761caaf997be4d214ea2b921a4387965a67d168b52ea29ae9185de20192f7b4b9169a887beb19d22e5776ff0bb0b68907e177b11a8043"
-# SHA512 checksum of the binary (see https://storage.googleapis.com/kubernetes-release/release/v1.27.1/bin/linux/amd64/kubectl.sha512)
-kubectl_checksum_binary: "sha512:45c837500fd821553a76dfec626cbbe44ac9c5c2c82984e8cd1073615ed4707e69b0f6bd7adf001e0ddbcc89ccc7bca38162e7ee778473d59a09c91f3d99f7c2"
+kubectl_checksum_archive: "sha512:42ac0cdfb1d961cb14fbdf09370b0798a1cd687d576ded4c85a2574a2adc48e514c7df9c905f1e851fab2f69246efee73971fd39838351d3b194881cfa3b5409"
+# SHA512 checksum of the binary (see https://storage.googleapis.com/kubernetes-release/release/v1.27.4/bin/linux/amd64/kubectl.sha512)
+kubectl_checksum_binary: "sha512:73f3c5f343d52f5d87563666ed7ee0ccca84a1bc6dfb34d10baf9e3af1adf2358d4218a3ac4f8e8329a12c01dbf6dbbd8e77ff410041bfed93d979580d9bc749"
 
 # Where to install "kubectl" binary
 kubectl_bin_directory: "/usr/local/bin"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,7 @@ galaxy_info:
     - name: Debian
       versions:
         - bullseye
+        - bookworm
   galaxy_tags:
     - kubernetes
     - kubectl

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - bionic
         - focal
         - jammy
     - name: Debian

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,7 +13,6 @@ galaxy_info:
         - jammy
     - name: Debian
       versions:
-        - buster
         - bullseye
   galaxy_tags:
     - kubernetes

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -12,7 +12,7 @@
     - name: Call setup
       ansible.builtin.setup:
 
-- hosts: test-kubectl-1804,test-kubectl-2004,test-kubectl-2204
+- hosts: test-kubectl-2004,test-kubectl-2204
   vars_files:
     - vars/ubuntu.yml
   tasks:
@@ -20,7 +20,7 @@
       ansible.builtin.include_role:
         name: githubixx.kubectl
 
-- hosts: test-kubectl-debian10,test-kubectl-debian11
+- hosts: test-kubectl-debian11,test-kubectl-debian12
   tasks:
     - name: Include kubectl role
       ansible.builtin.include_role:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,17 +1,4 @@
 ---
-- hosts: all
-  gather_facts: false
-  tasks:
-    - name: Install Python
-      ansible.builtin.raw: |
-        apt-get update
-        apt-get -y install ca-certificates python3
-      changed_when: false
-      failed_when: false
-
-    - name: Call setup
-      ansible.builtin.setup:
-
 - hosts: test-kubectl-2004,test-kubectl-2204
   vars_files:
     - vars/ubuntu.yml

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -17,9 +17,6 @@ platforms:
   - name: test-kubectl-2004
     image: ubuntu:20.04
     pre_build_image: true
-  - name: test-kubectl-1804
-    image: ubuntu:18.04
-    pre_build_image: true
   - name: test-kubectl-debian10
     image: debian:10
     pre_build_image: true

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -20,6 +20,9 @@ platforms:
   - name: test-kubectl-debian11
     image: debian:11
     pre_build_image: true
+  - name: test-kubectl-debian12
+    image: debian:12
+    pre_build_image: true
 
 provisioner:
   name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -17,9 +17,6 @@ platforms:
   - name: test-kubectl-2004
     image: ubuntu:20.04
     pre_build_image: true
-  - name: test-kubectl-debian10
-    image: debian:10
-    pre_build_image: true
   - name: test-kubectl-debian11
     image: debian:11
     pre_build_image: true

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,16 @@
+---
+# Copyright (C) 2023 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: Install Python
+      ansible.builtin.raw: |
+        apt-get update
+        apt-get -y install ca-certificates python3
+      changed_when: false
+      failed_when: false
+
+    - name: Call setup
+      ansible.builtin.setup:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -2,7 +2,7 @@
 - name: Verify setup
   hosts: all
   vars:
-    expected_output: "v1.27.1"
+    expected_output: "v1.27.4"
   tasks:
     - name: Execute kubectl version to capture output
       ansible.builtin.command: kubectl version --client=true


### PR DESCRIPTION
- update kubectl to `v1.27.4`
- remove Ubuntu `18.04` support (reached EOL)
- remove Debian `10` (Buster) support (reached EOL)
- add Debian `12` (Bookworm) support
- refactor Molecule test