### PR TITLE
23.0.0+1.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 23.0.0+1.28.1
+
+- update kubectl to `v1.28.1`
+- change download URL from `storage.googleapis.com` to `cdn.dl.k8s.io`
+- fix comment for `kubectl_download_filetype` variable
+- `kubectl_checksum_binary`: download checksum file for kubectl binary from `cdn.dl.k8s.io`
+
 ## 22.0.1+1.27.4
 
 - update kubectl to `v1.27.4`

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ kubectl_checksum_archive: "sha512:b5e9823886c8c26c22078cf5cd233612f38240e5ceb3c7
 # Further information:
 #   - https://kubernetes.io/releases/download/#binaries
 #   - https://www.downloadkubernetes.com/
-kubectl_checksum_binary: "sha512:https://cdn.dl.k8s.io/release/v{{ kubectl_version }}/bin/linux/amd64/kubectl.sha256"
+kubectl_checksum_binary: "sha512:https://cdn.dl.k8s.io/release/v{{ kubectl_version }}/bin/{{ kubectl_os }}/{{ kubectl_arch }}/kubectl.sha512"
 
 # Where to install "kubectl" binary
 kubectl_bin_directory: "/usr/local/bin"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Role Variables
 ```yaml
 ---
 # "kubectl" version to install
-kubectl_version: "1.27.4"
+kubectl_version: "1.28.1"
 
 # The default "archive" will download "kubectl" as a ".tar.gz" file. This is
 # about 2.5x smaller then "binary" but the tarball needs to be unarchived
@@ -30,8 +30,8 @@ kubectl_version: "1.27.4"
 # If download file size is important for you (e.g. slow download or download
 # over mobile link) stay with "archive". Otherwise "binary" might be an option.
 kubectl_download_filetype: "binary"
-# SHA512 checksum of the .tar.gz file (see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#client-binaries)
-kubectl_checksum_archive: "sha512:42ac0cdfb1d961cb14fbdf09370b0798a1cd687d576ded4c85a2574a2adc48e514c7df9c905f1e851fab2f69246efee73971fd39838351d3b194881cfa3b5409"
+# SHA512 checksum of the .tar.gz file (see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#client-binaries)
+kubectl_checksum_archive: "sha512:b5e9823886c8c26c22078cf5cd233612f38240e5ceb3c7bc5c032fbbfee59f6a631b53aa541bf8afc2eba496f5d0476357d1738cf771aaa95661c83d91372b51"
 # SHA512 checksum of the binary (see https://storage.googleapis.com/kubernetes-release/release/v1.27.4/bin/linux/amd64/kubectl.sha512)
 kubectl_checksum_binary: "sha512:73f3c5f343d52f5d87563666ed7ee0ccca84a1bc6dfb34d10baf9e3af1adf2358d4218a3ac4f8e8329a12c01dbf6dbbd8e77ff410041bfed93d979580d9bc749"
 

--- a/README.md
+++ b/README.md
@@ -21,17 +21,21 @@ Role Variables
 # "kubectl" version to install
 kubectl_version: "1.28.1"
 
-# The default "archive" will download "kubectl" as a ".tar.gz" file. This is
-# about 2.5x smaller then "binary" but the tarball needs to be unarchived
-# by the role first after downloading.
+# The default "binary" will download "kubectl" as a binary file. This is
+# about 2.5x bigger then the ".tar.gz" file. The tarball needs to be unarchived
+# by the role first after downloading and is smaller.
+#
 # If you specify "binary" the "kubectl" binary file will be downloaded. In
 # contrast to the tarball the binary file is about 2.5x bigger but doesn't
 # need to be unarchived by this role.
+#
 # If download file size is important for you (e.g. slow download or download
 # over mobile link) stay with "archive". Otherwise "binary" might be an option.
 kubectl_download_filetype: "binary"
+#
 # SHA512 checksum of the .tar.gz file (see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#client-binaries)
 kubectl_checksum_archive: "sha512:b5e9823886c8c26c22078cf5cd233612f38240e5ceb3c7bc5c032fbbfee59f6a631b53aa541bf8afc2eba496f5d0476357d1738cf771aaa95661c83d91372b51"
+#
 # SHA512 checksum of the binary. There is normally no need to change it.
 # Further information:
 #   - https://kubernetes.io/releases/download/#binaries

--- a/README.md
+++ b/README.md
@@ -32,8 +32,11 @@ kubectl_version: "1.28.1"
 kubectl_download_filetype: "binary"
 # SHA512 checksum of the .tar.gz file (see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#client-binaries)
 kubectl_checksum_archive: "sha512:b5e9823886c8c26c22078cf5cd233612f38240e5ceb3c7bc5c032fbbfee59f6a631b53aa541bf8afc2eba496f5d0476357d1738cf771aaa95661c83d91372b51"
-# SHA512 checksum of the binary (see https://storage.googleapis.com/kubernetes-release/release/v1.27.4/bin/linux/amd64/kubectl.sha512)
-kubectl_checksum_binary: "sha512:73f3c5f343d52f5d87563666ed7ee0ccca84a1bc6dfb34d10baf9e3af1adf2358d4218a3ac4f8e8329a12c01dbf6dbbd8e77ff410041bfed93d979580d9bc749"
+# SHA512 checksum of the binary. There is normally no need to change it.
+# Further information:
+#   - https://kubernetes.io/releases/download/#binaries
+#   - https://www.downloadkubernetes.com/
+kubectl_checksum_binary: "sha512:https://cdn.dl.k8s.io/release/v{{ kubectl_version }}/bin/linux/amd64/kubectl.sha256"
 
 # Where to install "kubectl" binary
 kubectl_bin_directory: "/usr/local/bin"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # "kubectl" version to install
-kubectl_version: "1.27.4"
+kubectl_version: "1.28.1"
 
 # The default "archive" will download "kubectl" as a ".tar.gz" file. This is
 # about 2.5x smaller then "binary" but the tarball needs to be unarchived
@@ -11,8 +11,8 @@ kubectl_version: "1.27.4"
 # If download file size is important for you (e.g. slow download or download
 # over mobile link) stay with "archive". Otherwise "binary" might be an option.
 kubectl_download_filetype: "binary"
-# SHA512 checksum of the .tar.gz file (see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#client-binaries)
-kubectl_checksum_archive: "sha512:42ac0cdfb1d961cb14fbdf09370b0798a1cd687d576ded4c85a2574a2adc48e514c7df9c905f1e851fab2f69246efee73971fd39838351d3b194881cfa3b5409"
+# SHA512 checksum of the .tar.gz file (see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#client-binaries)
+kubectl_checksum_archive: "sha512:b5e9823886c8c26c22078cf5cd233612f38240e5ceb3c7bc5c032fbbfee59f6a631b53aa541bf8afc2eba496f5d0476357d1738cf771aaa95661c83d91372b51"
 # SHA512 checksum of the binary (see https://storage.googleapis.com/kubernetes-release/release/v1.27.4/bin/linux/amd64/kubectl.sha512)
 kubectl_checksum_binary: "sha512:73f3c5f343d52f5d87563666ed7ee0ccca84a1bc6dfb34d10baf9e3af1adf2358d4218a3ac4f8e8329a12c01dbf6dbbd8e77ff410041bfed93d979580d9bc749"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,8 +13,11 @@ kubectl_version: "1.28.1"
 kubectl_download_filetype: "binary"
 # SHA512 checksum of the .tar.gz file (see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#client-binaries)
 kubectl_checksum_archive: "sha512:b5e9823886c8c26c22078cf5cd233612f38240e5ceb3c7bc5c032fbbfee59f6a631b53aa541bf8afc2eba496f5d0476357d1738cf771aaa95661c83d91372b51"
-# SHA512 checksum of the binary (see https://storage.googleapis.com/kubernetes-release/release/v1.27.4/bin/linux/amd64/kubectl.sha512)
-kubectl_checksum_binary: "sha512:73f3c5f343d52f5d87563666ed7ee0ccca84a1bc6dfb34d10baf9e3af1adf2358d4218a3ac4f8e8329a12c01dbf6dbbd8e77ff410041bfed93d979580d9bc749"
+# SHA512 checksum of the binary. There is normally no need to change it.
+# Further information:
+#   - https://kubernetes.io/releases/download/#binaries
+#   - https://www.downloadkubernetes.com/
+kubectl_checksum_binary: "sha512:https://cdn.dl.k8s.io/release/v{{ kubectl_version }}/bin/linux/amd64/kubectl.sha256"
 
 # Where to install "kubectl" binary
 kubectl_bin_directory: "/usr/local/bin"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,17 +2,21 @@
 # "kubectl" version to install
 kubectl_version: "1.28.1"
 
-# The default "archive" will download "kubectl" as a ".tar.gz" file. This is
-# about 2.5x smaller then "binary" but the tarball needs to be unarchived
-# by the role first after downloading.
+# The default "binary" will download "kubectl" as a binary file. This is
+# about 2.5x bigger then the ".tar.gz" file. The tarball needs to be unarchived
+# by the role first after downloading and is smaller.
+#
 # If you specify "binary" the "kubectl" binary file will be downloaded. In
 # contrast to the tarball the binary file is about 2.5x bigger but doesn't
 # need to be unarchived by this role.
+#
 # If download file size is important for you (e.g. slow download or download
 # over mobile link) stay with "archive". Otherwise "binary" might be an option.
 kubectl_download_filetype: "binary"
+#
 # SHA512 checksum of the .tar.gz file (see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#client-binaries)
 kubectl_checksum_archive: "sha512:b5e9823886c8c26c22078cf5cd233612f38240e5ceb3c7bc5c032fbbfee59f6a631b53aa541bf8afc2eba496f5d0476357d1738cf771aaa95661c83d91372b51"
+#
 # SHA512 checksum of the binary. There is normally no need to change it.
 # Further information:
 #   - https://kubernetes.io/releases/download/#binaries

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,7 @@ kubectl_checksum_archive: "sha512:b5e9823886c8c26c22078cf5cd233612f38240e5ceb3c7
 # Further information:
 #   - https://kubernetes.io/releases/download/#binaries
 #   - https://www.downloadkubernetes.com/
-kubectl_checksum_binary: "sha512:https://cdn.dl.k8s.io/release/v{{ kubectl_version }}/bin/linux/amd64/kubectl.sha256"
+kubectl_checksum_binary: "sha512:https://cdn.dl.k8s.io/release/v{{ kubectl_version }}/bin/{{ kubectl_os }}/{{ kubectl_arch }}/kubectl.sha512"
 
 # Where to install "kubectl" binary
 kubectl_bin_directory: "/usr/local/bin"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -2,7 +2,7 @@
 - name: Verify setup
   hosts: all
   vars:
-    expected_output: "v1.27.4"
+    expected_output: "v1.28.1"
   tasks:
     - name: Execute kubectl version to capture output
       ansible.builtin.command: kubectl version --client=true

--- a/tasks/setup-binary.yml
+++ b/tasks/setup-binary.yml
@@ -1,7 +1,7 @@
 ---
 - name: Download kubectl binary
   ansible.builtin.get_url:
-    url: "https://storage.googleapis.com/kubernetes-release/release/v{{ kubectl_version }}/bin/{{ kubectl_os }}/{{ kubectl_arch }}/kubectl"
+    url: "https://cdn.dl.k8s.io/release/v{{ kubectl_version }}/bin/{{ kubectl_os }}/{{ kubectl_arch }}/kubectl"
     checksum: "{{ kubectl_checksum_binary }}"
     dest: "{{ kubectl_tmp_directory }}"
     mode: 0600


### PR DESCRIPTION
- update kubectl to `v1.28.1`
- change download URL from `storage.googleapis.com` to `cdn.dl.k8s.io`
- fix comment for `kubectl_download_filetype` variable
- `kubectl_checksum_binary`: download checksum file for kubectl binary from `cdn.dl.k8s.io`