### PR TITLE
23.2.0+1.30.5

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -5,3 +5,12 @@ rules:
   line-length:
     max: 300
     level: warning
+  comments-indentation: disable
+  comments:
+    min-spaces-from-content: 1
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,19 @@
 # Changelog
 
+## 23.2.0+1.30.5
+
+- update kubectl to `v1.30.5`
+- Download URL of `kubectl` archive has changed. `https://storage.googleapis.com` doesn't work anymore. Using `https://dl.k8s.io` instead now (see [Client Binaries](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md#client-binaries)).
+- update `.yamllint`
+- update `meta/main.yml`
+- Molecule: update tests
+- Molecule: fix various `ansible-lint` issues
+
 ## 23.1.0+1.29.3
 
 - update kubectl to `v1.29.3`
 - update Github workflow
-- update .yamllint
+- update `.yamllint`
 - Molecule: update tests
 - Molecule: fix various ansible-lint issues
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,60 @@
-ansible-role-kubectl
-====================
+# ansible-role-kubectl
 
-Installs kubectl command line utility used to interact with the Kubernetes API Server.
+Installs `kubectl` command line utility used to interact with the Kubernetes API Server.
 
-Versions
---------
+## Versions
 
-I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `23.0.2+1.28.5` means this is release `23.0.2` of this role and `kubectl` client binary version is `1.28.5`. If the role itself changes `X.Y.Z` before `+` will increase. If the Kubernetes version changes `X.Y.Z` after `+` will increase. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific Kubernetes release.
+I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `23.2.0+1.30.5` means this is release `23.2.0` of this role and `kubectl` client binary version is `1.30.5`. If the role itself changes `X.Y.Z` before `+` will increase. If the Kubernetes version changes `X.Y.Z` after `+` will increase. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific Kubernetes release.
 
-Changelog
----------
+## Changelog
 
-see [CHANGELOG](https://github.com/githubixx/ansible-role-kubectl/blob/master/CHANGELOG.md)
+**Change history:**
 
-Role Variables
---------------
+See full [CHANGELOG](https://github.com/githubixx/ansible-role-kubectl/blob/master/CHANGELOG.md)
+
+**Recent changes:**
+
+## 23.2.0+1.30.5
+
+- update kubectl to `v1.30.5`
+- Download URL of `kubectl` archive has changed. `https://storage.googleapis.com` doesn't work anymore. Using `https://dl.k8s.io` instead now (see [Client Binaries](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md#client-binaries)).
+- update `.yamllint`
+- update `meta/main.yml`
+- Molecule: update tests
+- Molecule: fix various `ansible-lint` issues
+
+## 23.1.0+1.29.3
+
+- update kubectl to `v1.29.3`
+- update Github workflow
+- update .yamllint
+- Molecule: update tests
+- Molecule: fix various ansible-lint issues
+
+## Installation
+
+- Directly download from Github (Change into Ansible roles directory before cloning. You can figure out the role path by using `ansible-config dump | grep DEFAULT_ROLES_PATH` command):
+`git clone https://github.com/githubixx/ansible-role-kubectl.git githubixx.kubectl`
+
+- Via `ansible-galaxy` command and download directly from Ansible Galaxy:
+`ansible-galaxy install role githubixx.kubectl`
+
+- Create a `requirements.yml` file with the following content (this will download the role from Github) and install with
+`ansible-galaxy role install -r requirements.yml` (change `version` if needed):
+
+```yaml
+---
+roles:
+  - name: githubixx.kubectl
+    src: https://github.com/githubixx/ansible-role-kubectl.git
+    version: 23.2.0+1.30.5
+```
+
+## Role Variables
 
 ```yaml
 # "kubectl" version to install
-kubectl_version: "1.29.3"
+kubectl_version: "1.30.5"
 
 # The default "binary" will download "kubectl" as a binary file. This is
 # about 2.5x bigger then the ".tar.gz" file. The tarball needs to be unarchived
@@ -64,8 +100,7 @@ kubectl_os: "linux"  # use "darwin" for MacOS X, "windows" for Windows
 kubectl_arch: "amd64"  # other possible values: "386","arm64","arm","ppc64le","s390x"
 ```
 
-Testing
--------
+## Testing
 
 This role has a small test setup that is created using [molecule](https://github.com/ansible-community/molecule). To run the tests follow the molecule [install guide](https://molecule.readthedocs.io/en/latest/installation.html). Also ensure that a Docker daemon runs on your machine.
 
@@ -82,7 +117,7 @@ Afterwards molecule can be executed:
 molecule converge
 ```
 
-This will setup a few Docker container with Ubuntu 20.04/22.04 and Debian 11/12 with `kubectl` installed. To verify if everything worked:
+This will setup a few Docker container with Ubuntu 20.04/22.04/24.04 and Debian 11/12 with `kubectl` installed. To verify if everything worked:
 
 ```bash
 molecule verify
@@ -94,8 +129,7 @@ To clean up run
 molecule destroy
 ```
 
-Example Playbook
-----------------
+## Example Playbook
 
 ```yaml
 - hosts: your-host
@@ -103,12 +137,10 @@ Example Playbook
     - githubixx.kubectl
 ```
 
-License
--------
+## License
 
 GNU GENERAL PUBLIC LICENSE Version 3
 
-Author Information
-------------------
+## Author Information
 
 [TauCeti Blog](http://www.tauceti.blog)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # "kubectl" version to install
-kubectl_version: "1.29.3"
+kubectl_version: "1.30.5"
 
 # The default "binary" will download "kubectl" as a binary file. This is
 # about 2.5x bigger then the ".tar.gz" file. The tarball needs to be unarchived
@@ -15,8 +15,8 @@ kubectl_version: "1.29.3"
 kubectl_download_filetype: "binary"
 #
 # SHA512 checksum of the "kubernetes-client-linux-amd64.tar.gz" file
-# (see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.29.md#client-binaries)
-kubectl_checksum_archive: "sha512:c9cc7ab9e3aa776f2daab3a9e10ee78d57d0c081ef43f8032de36a61c6425ba527d5df92611b058672be0975a6b97ad3f3a169e282c26275d2c0e59e1f9b1173"
+# (see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md#client-binaries)
+kubectl_checksum_archive: "sha512:7551aba20eef3e2fb2076994a1a524b2ea2ecd85d47525845af375acf236b8afd1cd6873815927904fb7d6cf7375cfa5c56cedefad06bf18aa7d6d46bd28d287"
 #
 # SHA512 checksum of the binary. There is normally no need to change it.
 # Further information:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,12 +9,13 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - focal
-        - jammy
+        - "focal"
+        - "jammy"
+        - "noble"
     - name: Debian
       versions:
-        - bullseye
-        - bookworm
+        - "bullseye"
+        - "bookworm"
   galaxy_tags:
     - kubernetes
     - kubectl

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,6 +1,6 @@
 ---
 - name: Setup Ubuntu hosts
-  hosts: test-kubectl-2004,test-kubectl-2204
+  hosts: test-kubectl-2004,test-kubectl-2204,test-kubectl-2404
   vars_files:
     - vars/ubuntu.yml
   tasks:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -11,6 +11,9 @@ lint: |
   ansible-lint .
 
 platforms:
+  - name: test-kubectl-2404
+    image: ubuntu:24.04
+    pre_build_image: true
   - name: test-kubectl-2204
     image: ubuntu:22.04
     pre_build_image: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -2,7 +2,7 @@
 - name: Verify setup
   hosts: all
   vars:
-    expected_output: "v1.29.3"
+    expected_output: "v1.30.5"
   tasks:
     - name: Execute kubectl version to capture output
       ansible.builtin.command: kubectl version --client=true

--- a/tasks/setup-archive.yml
+++ b/tasks/setup-archive.yml
@@ -1,10 +1,10 @@
 ---
 - name: Download kubectl archive
   ansible.builtin.get_url:
-    url: "https://storage.googleapis.com/kubernetes-release/release/v{{ kubectl_version }}/kubernetes-client-{{ kubectl_os }}-{{ kubectl_arch }}.tar.gz"
+    url: "https://dl.k8s.io/v{{ kubectl_version }}/kubernetes-client-{{ kubectl_os }}-{{ kubectl_arch }}.tar.gz"
     checksum: "{{ kubectl_checksum_archive }}"
     dest: "{{ kubectl_tmp_directory }}"
-    mode: 0600
+    mode: "0600"
   tags:
     - kubectl
 

--- a/tasks/setup-binary.yml
+++ b/tasks/setup-binary.yml
@@ -4,7 +4,7 @@
     url: "https://cdn.dl.k8s.io/release/v{{ kubectl_version }}/bin/{{ kubectl_os }}/{{ kubectl_arch }}/kubectl"
     checksum: "{{ kubectl_checksum_binary }}"
     dest: "{{ kubectl_tmp_directory }}"
-    mode: 0600
+    mode: "0600"
   tags:
     - kubectl
 


### PR DESCRIPTION
- update kubectl to `v1.30.5`
- Download URL of `kubectl` archive has changed. `https://storage.googleapis.com` doesn't work anymore. Using `https://dl.k8s.io` instead now (see [Client Binaries](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md#client-binaries)).
- update `.yamllint`
- update `meta/main.yml`
- Molecule: update tests
- Molecule: fix various `ansible-lint` issues