### PR TITLE
fix: replace local env lookup with remote env

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ kubectl_checksum_binary: "sha512:https://cdn.dl.k8s.io/release/v{{ kubectl_versi
 kubectl_bin_directory: "/usr/local/bin"
 
 # Directory to store the kubectl archive
-kubectl_tmp_directory: "{{ lookup('env', 'TMPDIR') | default('/tmp', true) }}"
+kubectl_tmp_directory: "{{ ansible_facts.env.TMPDIR | default('/tmp', true) }}"
 
 # Owner of "kubectl" binary
 kubectl_owner: "root"

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ kubectl_checksum_binary: "sha512:https://cdn.dl.k8s.io/release/v{{ kubectl_versi
 kubectl_bin_directory: "/usr/local/bin"
 
 # Directory to store the kubectl archive
-kubectl_tmp_directory: "{{ ansible_facts.env.TMPDIR | default('/tmp', true) }}"
+kubectl_tmp_directory: "{{ ansible_env.TMPDIR | default('/tmp', true) }}"
 
 # Owner of "kubectl" binary
 kubectl_owner: "root"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,7 +33,7 @@ kubectl_checksum_binary: "sha512:https://cdn.dl.k8s.io/release/v{{ kubectl_versi
 kubectl_bin_directory: "/usr/local/bin"
 
 # Directory to store the kubectl archive
-kubectl_tmp_directory: "{{ lookup('env', 'TMPDIR') | default('/tmp', true) }}"
+kubectl_tmp_directory: "{{ ansible_facts.env.TMPDIR | default('/tmp', true) }}"
 
 # Owner of "kubectl" binary
 kubectl_owner: "root"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,7 +33,7 @@ kubectl_checksum_binary: "sha512:https://cdn.dl.k8s.io/release/v{{ kubectl_versi
 kubectl_bin_directory: "/usr/local/bin"
 
 # Directory to store the kubectl archive
-kubectl_tmp_directory: "{{ ansible_facts.env.TMPDIR | default('/tmp', true) }}"
+kubectl_tmp_directory: "{{ ansible_env.TMPDIR | default('/tmp', true) }}"
 
 # Owner of "kubectl" binary
 kubectl_owner: "root"


### PR DESCRIPTION
Hey, first of all, thanks for providing this role!

I'm using this on a Mac, and ran into some issues:

```
TASK [Install Kubectl] ********************************************************************************************************************************************************************************
included: githubixx.kubectl for 46.62.208.190

TASK [githubixx.kubectl : Include tasks based on download filetype] ***********************************************************************************************************************************
included: /Users/felix/.ansible/roles/githubixx.kubectl/tasks/setup-binary.yml for 46.62.208.190

TASK [githubixx.kubectl : Download kubectl binary] ****************************************************************************************************************************************************
[ERROR]: Task failed: Module failed: Destination /var/folders/yw/j2bslldj3lb2f91lk4wkgyr40000gn/T does not exist
Origin: /Users/felix/.ansible/roles/githubixx.kubectl/tasks/setup-binary.yml:2:3

1 ---
2 - name: Download kubectl binary
    ^ column 3

fatal: [46.62.208.190]: FAILED! => {"changed": false, "checksum_dest": null, "checksum_src": "362bc05481ea8ebfb275e20c7350738a02d98ea2", "dest": "/var/folders/yw/j2bslldj3lb2f91lk4wkgyr40000gn/T/", "elapsed": 0, "msg": "Destination /var/folders/yw/j2bslldj3lb2f91lk4wkgyr40000gn/T does not exist", "src": "/root/.ansible/tmp/ansible-tmp-1760007870.4895082-65505-119780295441203/tmpvpy5hf1w", "url": "https://cdn.dl.k8s.io/release/v1.29.3/bin/linux/amd64/kubectl"}
```

I think the problem is that the local ENV is checked, not what's on the host. This is fixed by using the `ansible-facts.env`. I think the issue only becomes apparent on Mac, not if you're running Linux.