### PR TITLE
25.0.0+1.34.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 25.0.2+1.34.4
+
+- update kubectl to `v1.34.4`
+
 ## 24.0.2+1.33.8
 
 - update kubectl to `v1.33.8`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## 25.0.2+1.34.4
+## 25.0.0+1.34.4
 
 - update kubectl to `v1.34.4`
+- replace injected `ansible_*` facts usage with `ansible_facts[...]` (prepares for ansible-core 2.24 where `INJECT_FACTS_AS_VARS` default changes)
 
 ## 24.0.2+1.33.8
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-kubectl/blob/mast
 
 **Recent changes:**
 
+## 25.0.2+1.34.4
+
+- update kubectl to `v1.34.4`
+
 ## 24.0.2+1.33.8
 
 - update kubectl to `v1.33.8`
@@ -64,14 +68,14 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-kubectl/blob/mast
 roles:
   - name: githubixx.kubectl
     src: https://github.com/githubixx/ansible-role-kubectl.git
-    version: 24.0.2+1.33.8
+    version: 25.0.2+1.34.4
 ```
 
 ## Role Variables
 
 ```yaml
 # "kubectl" version to install
-kubectl_version: "1.33.8"
+kubectl_version: "1.34.4"
 
 # The default "binary" will download "kubectl" as a binary file. This is
 # about 2.5x bigger then the ".tar.gz" file. The tarball needs to be unarchived

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-kubectl/blob/mast
 
 **Recent changes:**
 
-## 25.0.2+1.34.4
+## 25.0.0+1.34.4
 
 - update kubectl to `v1.34.4`
+- replace injected `ansible_*` facts usage with `ansible_facts[...]` (prepares for ansible-core 2.24 where `INJECT_FACTS_AS_VARS` default changes)
 
 ## 24.0.2+1.33.8
 
@@ -30,7 +31,7 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-kubectl/blob/mast
 
 ## 24.0.0+1.33.5
 
-- **Potential breaking change**: `kubectl_tmp_directory` default value changed from `{{ lookup('env', 'TMPDIR') | default('/tmp', true) }}` to `{{ ansible_env.TMPDIR | default('/tmp', true) }}`. The old implementation looked up `TMPDIR` variable on the Ansible controller. But that was not the intention here. The new default uses the `TMPDIR` value of the remote machine where `kubectl` should be installed. If you set this variable on your own nothing will change for you. And even if you use the default setting chances are low that you notice the change. Still, please test if this change affects you (contribution by @fhennig).
+- **Potential breaking change**: `kubectl_tmp_directory` default value changed from `{{ lookup('env', 'TMPDIR') | default('/tmp', true) }}` to `{{ ansible_facts['env']['TMPDIR'] | default('/tmp', true) }}`. The old implementation looked up `TMPDIR` variable on the Ansible controller. But that was not the intention here. The new default uses the `TMPDIR` value of the remote machine where `kubectl` should be installed. If you set this variable on your own nothing will change for you. And even if you use the default setting chances are low that you notice the change. Still, please test if this change affects you (contribution by @fhennig).
 - update kubectl to `v1.33.5`
 
 ## 23.4.0+1.32.7
@@ -68,7 +69,7 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-kubectl/blob/mast
 roles:
   - name: githubixx.kubectl
     src: https://github.com/githubixx/ansible-role-kubectl.git
-    version: 25.0.2+1.34.4
+    version: 25.0.0+1.34.4
 ```
 
 ## Role Variables
@@ -105,7 +106,7 @@ kubectl_checksum_binary: "sha512:https://dl.k8s.io/release/v{{ kubectl_version }
 kubectl_bin_directory: "/usr/local/bin"
 
 # Directory to store the kubectl archive
-kubectl_tmp_directory: "{{ ansible_env.TMPDIR | default('/tmp', true) }}"
+kubectl_tmp_directory: "{{ ansible_facts['env']['TMPDIR'] | default('/tmp', true) }}"
 
 # Owner of "kubectl" binary
 kubectl_owner: "root"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # "kubectl" version to install
-kubectl_version: "1.33.8"
+kubectl_version: "1.34.4"
 
 # The default "binary" will download "kubectl" as a binary file. This is
 # about 2.5x bigger then the ".tar.gz" file. The tarball needs to be unarchived
@@ -20,7 +20,7 @@ kubectl_download_filetype: "binary"
 #
 # SHA512 checksum of the "kubernetes-client-linux-amd64.tar.gz" file
 # (see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#client-binaries)
-kubectl_checksum_archive: "sha512:0dc7ccca28a4272147de370af7d429b86426faf3c2ded1241c33a57c12f13d728cc207b7c2a46f0dfd28b46bdfde7152bc15afc446dd5a41ce3b14f882614dbb"
+kubectl_checksum_archive: "sha512:018d0a75b74b55942a0777afc7edf64ca98c004e6e12f9dc93ad75c26cb58089104ba0f9ceae2f0be5a6f6854948c705b0eb828f0960302a0ff84d57c464fc09"
 
 #
 # SHA512 checksum of the binary. There is normally no need to change it.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,7 +33,7 @@ kubectl_checksum_binary: "sha512:https://dl.k8s.io/release/v{{ kubectl_version }
 kubectl_bin_directory: "/usr/local/bin"
 
 # Directory to store the kubectl archive
-kubectl_tmp_directory: "{{ ansible_env.TMPDIR | default('/tmp', true) }}"
+kubectl_tmp_directory: "{{ ansible_facts['env']['TMPDIR'] | default('/tmp', true) }}"
 
 # Owner of "kubectl" binary
 kubectl_owner: "root"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -5,7 +5,7 @@
 - name: Verify setup
   hosts: all
   vars:
-    expected_output: "v1.33.8"
+    expected_output: "v1.34.4"
   tasks:
     - name: Execute kubectl version to capture output
       ansible.builtin.command: kubectl version --client=true


### PR DESCRIPTION
- update kubectl to `v1.34.4`
- replace injected `ansible_*` facts usage with `ansible_facts[...]` (prepares for ansible-core 2.24 where `INJECT_FACTS_AS_VARS` default changes)